### PR TITLE
Fix type for normalizer filter function

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -104,7 +104,7 @@ type BoundQueries<T> = { [P in keyof T]: Bound<T[P]> }
 export type NativeTestInstance = Omit<ReactTestInstance, 'find' | 'findAllByProps' | 'findAllByType' | 'findByProps' | 'findByType' | 'instance'>
 
 export type TextMatch = string | RegExp | ((value: string) => boolean)
-export type FilterFn = (value: string, index: number) => boolean
+export type FilterFn = (node: NativeTestInstance, index: number) => boolean
 export type NormalizerFn = (input: string) => string
 
 export interface NormalizerOptions {


### PR DESCRIPTION
**What**:

The options normalizer filter function receives the node element instead of a string.
Fixed the typescript definition for it.

**Why**:

This is needed to pass an options object with a filter function to the queries when using javascript

**How**:

Just changed the typescript definition to use a NativeTestInstance instead of string for the first argument of the FilterFn type. Also changed the parameter name from value to node, to match the actual code.

**Checklist**:

<!-- Have you done all of these things?  -->
<!-- Add "(N/A)" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/bcarroll22/native-testing-library-docs) N/A
- [x] Typescript definitions updated
- [ ] Tests
- [x] Ready to be merged <!-- In your opinion -->

<!-- feel free to add additional comments -->
